### PR TITLE
Fixes and enhancement in solver exploration

### DIFF
--- a/src/models.h
+++ b/src/models.h
@@ -509,6 +509,10 @@ namespace tobor {
 
 			// cell_id_type::int_type for cell ids
 
+
+			// here it should not use a dependent name without alias-defining it in the class itself!
+			// like piece_id_int_type, we already defined class piece_id as a wrapper.
+
 			static constexpr typename pieces_quantity_type::int_type COUNT_TARGET_PIECES{ Pieces_Quantity_Type::COUNT_TARGET_PIECES };
 
 			static constexpr typename pieces_quantity_type::int_type COUNT_NON_TARGET_PIECES{ Pieces_Quantity_Type::COUNT_NON_TARGET_PIECES };

--- a/src/solver.h
+++ b/src/solver.h
@@ -586,7 +586,7 @@ namespace tobor {
 				for (size_type expand_index{ 0 }; expand_index < optimal_solution_size; ++expand_index) {
 
 					// condition: visited_game_states.size() == expand_size + 1
-					
+
 					visited_game_states[expand_index].shrink_to_fit();
 
 					visited_game_states.emplace_back();
@@ -626,10 +626,23 @@ namespace tobor {
 							++index_candidate
 							)
 						{
-							if (candidates_for_successor_states[index_candidate].next_cell_paired_enable.first.piece_positions[index_candidate / 4] == target_cell) {
-								// does not work for sorted final pieces!!
+							constexpr bool IS_SORTED{ positions_of_pieces_type::SORTED_TARGET_PIECES };
 
-								optimal_solution_size = current_iterator->second.smallest_seen_step_distance_from_initial_state + 1;
+							if constexpr (IS_SORTED) {
+								for (typename positions_of_pieces_type::pieces_quantity_type::int_type index_target_piece{ 0 };
+									index_target_piece < positions_of_pieces_type::COUNT_TARGET_PIECES; // ### check again type consistency to be static_assert-ed for this inequation.
+									++index_target_piece)
+								{
+									if (candidates_for_successor_states[index_candidate].next_cell_paired_enable.first.piece_positions[index_target_piece] == target_cell) {
+										optimal_solution_size = current_iterator->second.smallest_seen_step_distance_from_initial_state + 1;
+									}
+								}
+							}
+							else {
+								if (candidates_for_successor_states[index_candidate].next_cell_paired_enable.first.piece_positions[index_candidate / 4] == target_cell) {
+									// does not work for sorted final pieces! In that case we do not know where the moved piece is located.
+									optimal_solution_size = current_iterator->second.smallest_seen_step_distance_from_initial_state + 1;
+								}
 							}
 						}
 

--- a/src/solver.h
+++ b/src/solver.h
@@ -614,10 +614,10 @@ namespace tobor {
 						}
 
 						/* order of candidates:
-						 piece 0: N E S E      <- target pieces come first!
-						 piece 1: N E S E
+						 piece 0: N E S W      <- target pieces come first!
+						 piece 1: N E S W
 						 ...
-						 piece last: N E S E
+						 piece last: N E S W
 						*/
 
 

--- a/src/solver.h
+++ b/src/solver.h
@@ -581,7 +581,10 @@ namespace tobor {
 				move_one_piece_calculator_type& engine,
 				const cell_id_type& target_cell
 			) {
-				// what if initial state is already final? check this! ####
+
+				if (visited_game_states[0][0]->first.is_final(target_cell)) {
+					return;
+				}
 
 				for (size_type expand_level_index{ 0 }; expand_level_index < optimal_solution_size; ++expand_level_index) {
 


### PR DESCRIPTION
Fixes:
* exploration on initial state being final (reported from GUI usage, fixes: #107)
* check for final state in case of multiple target pieces using color-agnostic mode (found by static code analysis, never practically reproduced this bug)