### PR TITLE
CI: remove qt5, update some images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,55 +16,15 @@ stages:
  - stage: Compile_and_Test
    dependsOn: []
    jobs:
-    - job: Qt_5___Clang_17
-      ${{ if eq(variables.USE_ARTIFICIAL_BUILD_DEPENDENCIES, true) }}:
-        dependsOn: [Qt_6, Qt_5]
-      timeoutInMinutes: 30
-      strategy:
-        matrix:
-          ubuntu_20_04:
-            imageName: "ubuntu-20.04"
-            the_name: "Azure Pipelines"
-          ubuntu_22_04:
-            imageName: "ubuntu-22.04"
-            the_name: "Azure Pipelines"
-
-      pool:
-        vmImage: $(imageName)
-        name: $(the_name)
-
-      steps:
-       - script: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x ./llvm.sh
-          sudo ./llvm.sh 17
-         displayName: "Install Clang 17"
-         condition: succeeded()
-       - script: sudo apt-get install qtbase5-dev libqt5svg5-dev libtbb-dev
-         displayName: "Install Qt + libtbb (Linux)"
-         condition: succeeded()
-       - script: git submodule update --init --recursive
-         displayName: "Init Git Submodules"
-         condition: succeeded()
-       - script: export CC="/usr/bin/clang-17"; export CXX="/usr/bin/clang++-17"; cmake -S . -B ./build/ -DUSE_QT6:BOOL=FALSE
-         displayName: "CMake: Create Project [clang 17] (Linux)"
-         condition: succeeded()
-       - script: cmake --build ./build --config Debug --verbose
-         displayName: "CMake: Compile and Link (Debug)"
-         condition: succeeded()
-       - script: cmake --build ./build --config Release --verbose
-         displayName: "CMake: Compile and Link (Release)"
-         condition: succeeded()
-       - script: ./build/test/TEST-$(project_name)
-         displayName: "Run Tests on Linux / Mac OS"
-         condition: succeeded()
-
     - job: Qt_6___Clang_17
       ${{ if eq(variables.USE_ARTIFICIAL_BUILD_DEPENDENCIES, true) }}:
-        dependsOn: [Qt_6, Qt_5]
+        dependsOn: [Qt_6]
       timeoutInMinutes: 30
       strategy:
         matrix:
+          ubuntu_latest:
+            imageName: "ubuntu-latest"
+            the_name: "Azure Pipelines"
           ubuntu_22_04:
             imageName: "ubuntu-22.04"
             the_name: "Azure Pipelines"
@@ -99,87 +59,13 @@ stages:
          displayName: "Run Tests on Linux / Mac OS"
          condition: succeeded()
 
-    - job: Qt_5
-      ${{ if eq(variables.USE_ARTIFICIAL_BUILD_DEPENDENCIES, true) }}:
-        dependsOn: [Qt_6]
-      timeoutInMinutes: 30
-      strategy:
-        matrix:
-          ubuntu_22_04:
-            imageName: "ubuntu-22.04"
-            the_name: "Azure Pipelines"
-
-          mac_12:
-            imageName: "macOS-12"
-            the_name: "Azure Pipelines"
-
-          mac_13:
-            imageName: "macOS-13"
-            the_name: "Azure Pipelines"
-
-          windows_2022:
-            imageName: "windows-2022"
-            the_name: "Azure Pipelines"
-
-          windows_2019:
-            imageName: "windows-2019"
-            the_name: "Azure Pipelines"
-
-      pool:
-        vmImage: $(imageName)
-        name: $(the_name)
-
-      steps:
-       - script: sudo apt-get update && sudo apt-get install qtbase5-dev libqt5svg5-dev libtbb-dev
-         displayName: "Install Qt + libtbb (Linux)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux'))
-       - script: (brew install qt@5 || brew install qt@5) && brew install tbb
-         displayName: "Install Qt +tbb (Darwin)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin'))
-       - script: |
-          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          pip install aqtinstall
-          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          aqt list-qt windows desktop
-          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          mkdir C:\Qt
-          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          aqt install-qt --outputdir C:\Qt windows desktop 5.15.2 win64_msvc2019_64
-          echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-         displayName: "Install Qt (Windows)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT'))
-       - script: git submodule update --init --recursive
-         displayName: "Init Git Submodules"
-         condition: succeeded()
-       - script: cmake -S . -B ./build/ -DCMAKE_PREFIX_PATH="C:\Qt\5.15.2\msvc2019_64" -DUSE_QT6:BOOL=FALSE
-         displayName: "CMake: Create Project (Windows)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT'))
-       - script: PATH="/usr/local/opt/qt@5/bin:$PATH" && cmake -S . -B ./build/ -DUSE_QT6:BOOL=FALSE
-         displayName: "CMake: Create Project (Darwin)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin'))
-       - script: cmake -S . -B ./build/ -DUSE_QT6:BOOL=FALSE
-         displayName: "CMake: Create Project (Linux)"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux'))
-       - script: cmake --build ./build --config Debug --verbose
-         displayName: "CMake: Compile and Link (Debug)"
-         condition: succeeded()
-       - script: cmake --build ./build --config Release --verbose
-         displayName: "CMake: Compile and Link (Release)"
-         condition: succeeded()
-       - script: ./build/test/TEST-$(project_name)
-         displayName: "Run Tests on Linux / Mac OS"
-         condition: and(succeeded(), ne( variables['Agent.OS'], 'Windows_NT'))
-       - script: tree /F .\build
-         displayName: "View tree of 'build\\' on Windows"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
-       - script: .\build\test\Release\TEST-$(project_name).exe
-         displayName: "Run Tests on Windows"
-         condition: and(succeeded(), eq( variables['Agent.OS'], 'Windows_NT' ))
-
     - job: Qt_6
       timeoutInMinutes: 30
       strategy:
         matrix:
+          ubuntu_latest:
+            imageName: "ubuntu-latest"
+            the_name: "Azure Pipelines"
           ubuntu_22_04:
             imageName: "ubuntu-22.04"
             the_name: "Azure Pipelines"
@@ -192,14 +78,13 @@ stages:
             imageName: "macOS-13"
             the_name: "Azure Pipelines"
 
+          windows_latest:
+            imageName: "windows-latest"
+            the_name: "Azure Pipelines"
+
           windows_2022:
             imageName: "windows-2022"
             the_name: "Azure Pipelines"
-
-          windows_2019:
-            imageName: "windows-2019"
-            the_name: "Azure Pipelines"
-
       pool:
         vmImage: $(imageName)
         name: $(the_name)
@@ -260,7 +145,7 @@ stages:
       timeoutInMinutes: 30
       strategy:
         matrix:
-          ubuntu_22_04:
+          ubuntu_latest:
             imageName: "ubuntu-latest"
             the_name: "Azure Pipelines"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,12 +70,12 @@ stages:
             imageName: "ubuntu-22.04"
             the_name: "Azure Pipelines"
 
-          mac_12:
-            imageName: "macOS-12"
+          macOS_latest:
+            imageName: "macOS-latest"
             the_name: "Azure Pipelines"
 
-          mac_13:
-            imageName: "macOS-13"
+          macOS_14:
+            imageName: "macOS-14"
             the_name: "Azure Pipelines"
 
           windows_latest:

--- a/src/models/direction.h
+++ b/src/models/direction.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace tobor {

--- a/src/world_generator_1_0.h
+++ b/src/world_generator_1_0.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <string>
 #include <tuple>
+#include <cstdint>
 
 namespace tobor {
 


### PR DESCRIPTION
See available images here: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=linux-images%2Cyaml

We remove old images, and also Qt 5 support

TODO: remove Qt5 from README.md.